### PR TITLE
Fix bug where toggling adds excess spaces in nav class.

### DIFF
--- a/responsive-nav.js
+++ b/responsive-nav.js
@@ -114,11 +114,12 @@ var responsiveNav = (function (window, document) {
 
     addClass = function (el, cls) {
       el.className += " " + cls;
+      el.className = el.className.replace(/(^\s*)|(\s*$)/g,"");
     },
 
     removeClass = function (el, cls) {
       var reg = new RegExp("(\\s|^)" + cls + "(\\s|$)");
-      el.className = el.className.replace(reg, " ");
+      el.className = el.className.replace(reg, " ").replace(/(^\s*)|(\s*$)/g,"");
     },
 
     log = function () {},


### PR DESCRIPTION
To reproduce the bug:
1. Go to the demo (http://viljamis.com/responsive-nav/)
2. Toggle the nav multiple times

The class name of the nav will have excess spaces in the front.
