### PR TITLE
Spell out the max-height thing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-
 # Responsive Nav
 
 ### Responsive navigation plugin without library dependencies and with fast touch screen support.
 
-[Responsive Nav](http://responsive-nav.com) is a tiny JavaScript plugin which weighs only 1.7 KB minified and Gzip’ed, and helps you to create a toggled navigation for small screens. It uses touch events and CSS3 transitions for the best possible performance. It also contains a “clever” workaround that makes it possible to transition from `height: 0` to `height: auto`, which isn’t normally possible with CSS3 transitions.
+[Responsive Nav](http://responsive-nav.com) is a tiny JavaScript plugin which weighs only 1.7 KB minified and Gzip’ed, and helps you to create a toggled navigation for small screens. It uses touch events and CSS3 transitions for the best possible performance. It also contains a workaround that simulates CSS Transitions between `height: 0` to `height: auto` using `max-height` instead.
 
 
 #### Features:


### PR DESCRIPTION
I think it's a clever workaround too. I love using it!

But... it's not original to this library and the old wording seemed to imply that you had successfully transitioned the height from auto somehow. I was kind of disappointed when I looked in the CSS file and found ol' ```max-height```

Might as well just explain how it works and educate people a little bit.