### PR TITLE
Prevent nav jumping if browser resized larger than 40em whilst nav open

### DIFF
--- a/responsive-nav.css
+++ b/responsive-nav.css
@@ -29,6 +29,8 @@
 @media screen and (min-width: 40em) {
   .js #nav {
     position: relative;
+  }
+  .js #nav.closed {
     max-height: none;
   }
   #nav-toggle {


### PR DESCRIPTION
Incase anyone resizes the browser whilst the nav is open, this prevents the nav from jumping back up and then showing.
