### PR TITLE
Correct name in Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "responsive-js",
+  "name": "responsive-nav",
   "version": "1.0.14",
   "main": [
     "responsive-nav.css",


### PR DESCRIPTION
The script is registered in the Bower registry as 'responsive-nav' but in the bower.json file it is incorrectly named as 'responsive-js'
