### PR TITLE
Set `navOpen` state in the `_init` method

### DIFF
--- a/responsive-nav.js
+++ b/responsive-nav.js
@@ -38,7 +38,7 @@ var responsiveNav = (function (window, document) {
     opts,
     navToggle,
     styleElement = document.createElement("style"),
-    navOpen = false,
+    navOpen,
 
     // fn arg can be an object or a function, thanks to handleEvent
     // read more at: http://www.thecssninja.com/javascript/handleevent
@@ -255,6 +255,7 @@ var responsiveNav = (function (window, document) {
     // Private methods
     _init: function () {
       addClass(nav, "closed");
+      navOpen = false;
       this._createToggle();
 
       addEvent(window, "load", this, false);


### PR DESCRIPTION
Set the `navOpen` state at the same time as the "closed" class is added,
i.e. in the `_init` method.

Fixes the issue where:
- initializing a new instance: `var nav = responsiveNav('#nav')`
- toggling it (to `navOpen = true`): `nav.toggle()`
- destroying it: `nav.destroy()`
- re-initializing it: `nav = responsiveNav('#nav')`
  Would cause the second initialization to have conflicting state
  `navOpen === true` and the "closed" class on the DOM element.
