### PR TITLE
Add SVG support?

### DIFF
--- a/responsive-nav.js
+++ b/responsive-nav.js
@@ -37,7 +37,7 @@
         return this;
       };
     }
-    /* exported addEvent, removeEvent, getChildren, setAttributes, addClass, removeClass, forEach */
+    /* exported addEvent, removeEvent, getChildren, setAttributes, getClass, addClass, removeClass, forEach */
     
     /**
      * Add Event
@@ -143,15 +143,25 @@
       },
     
       /**
+       * Gets the classname of an element.
+       *
+       * @param {element} element
+       * @return {string} the classes on the element
+       */
+      getClass = function (el) {
+        return el.getAttribute("class") || "";
+      },
+
+      /**
        * Adds a class to any element
        *
        * @param {element} element
        * @param {string}  class
        */
       addClass = function (el, cls) {
-        if (el.className.indexOf(cls) !== 0) {
-          el.className += " " + cls;
-          el.className = el.className.replace(/(^\s*)|(\s*$)/g,"");
+        if (getClass(el).indexOf(cls) !== 0) {
+          el.setAttribute("class", getClass(el) + " " + cls);
+          el.setAttribute("class", getClass(el).replace(/(^\s*)|(\s*$)/g,""));
         }
       },
     
@@ -163,7 +173,7 @@
        */
       removeClass = function (el, cls) {
         var reg = new RegExp("(\\s|^)" + cls + "(\\s|$)");
-        el.className = el.className.replace(reg, " ").replace(/(^\s*)|(\s*$)/g,"");
+        el.setAttribute("class", getClass(el).replace(reg, " ").replace(/(^\s*)|(\s*$)/g,""));
       },
     
       /**
@@ -348,7 +358,7 @@
           setAttributes(navToggle, {"aria-hidden": "false"});
 
           // If the navigation is hidden
-          if (nav.className.match(/(^|\s)closed(\s|$)/)) {
+          if (getClass(nav).match(/(^|\s)closed(\s|$)/)) {
             setAttributes(nav, {"aria-hidden": "true"});
             nav.style.position = "absolute";
           }


### PR DESCRIPTION
Hello. I've made a small-ish update to add support for using an inline SVG as a `customToggle`. This fixes a javascript error I've encountered when I tried this for a site I'm working on. I'm putting this PR up in case it might be worth applying, but obviously feel free to ignore it if it doesn't fit.

The error I encountered is...

```
Uncaught TypeError: el.className.indexOf is not a function
    addClass http://localhost:1313/j/responsive-nav.js:152
    open http://localhost:1313/j/responsive-nav.js:301
    toggle http://localhost:1313/j/responsive-nav.js:286
    _onTouchEnd http://localhost:1313/j/responsive-nav.js:584
    handleEvent http://localhost:1313/j/responsive-nav.js:386
    addEvent http://localhost:1313/j/responsive-nav.js:56
    _init http://localhost:1313/j/responsive-nav.js:432
    ResponsiveNav http://localhost:1313/j/responsive-nav.js:246
    responsiveNav http://localhost:1313/j/responsive-nav.js:653
    <anonymous> http://localhost:1313/:1381
```

The [documentation on MDN regarding `className`](https://developer.mozilla.org/en-US/docs/Web/API/Element/className#notes) mentions that if the element is an SVG then `className` returns an instance of SVGAnimatedString, rather than a string, which causes the error.

I've updated responsive-nav.js to use `getAttribute` to determine the class name, as well as using `setAttribute` to set the new class name, as recommended on MDN.